### PR TITLE
fix layout bug for narrow viewports

### DIFF
--- a/sass/page.scss
+++ b/sass/page.scss
@@ -32,15 +32,14 @@ a:visited {
 
 
 .section {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  margin: 0 auto;
   text-align: center;
 }
 
 .container {
     max-width: 60%;
     min-width: 30em;
+    margin: 0 auto;
 }
 
 .imgcontainer {


### PR DESCRIPTION
Here's a very easy fix to that viewport bug. It keeps the style of your site exactly the same except for when the viewport is smaller than your minimum width. Just a token of good will :)

<img width="548" alt="image" src="https://github.com/user-attachments/assets/b78a6478-9702-4ea5-b592-27898a252588" />
